### PR TITLE
Update slm.toml to include JSL

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -2,4 +2,4 @@ name = "connectors"
 version = "0.4.0"
 [dependencies]
 diodes = { git = "JITx-Inc/diodes", version = "0.2.0" }
-
+jsl = { git = "JITx-Inc/jsl", version = "0.9.3" }


### PR DESCRIPTION
While working with this repository I found out it had jsl missing as dependency, added it through `slm add -git JITx-Inc/jsl`
This fixes compile of src\components\USB\USBTypeC.stanza and others.